### PR TITLE
Status validation refactoring

### DIFF
--- a/openprocurement/audit/api/models.py
+++ b/openprocurement/audit/api/models.py
@@ -64,6 +64,7 @@ class Dialogue(Model):
 class Monitor(SchematicsDocument, Model):
 
     class Options:
+        _perm_edit_whitelist = whitelist("status", "dialogues")
         roles = {
             'plain': blacklist('_attachments', 'revisions') + schematics_embedded_role,
             'revision': whitelist('revisions'),
@@ -72,16 +73,8 @@ class Monitor(SchematicsDocument, Model):
                 'doc_id', '_attachments', 'monitoring_id',
                 'tender_owner_token', 'tender_owner'
             ) + schematics_embedded_role,
-            'edit_draft': blacklist(
-                'revisions', 'dateModified', 'dateCreated', 'monitoringPeriod',
-                'doc_id', '_attachments', 'tender_id', 'monitoring_id',
-                'tender_owner_token', 'tender_owner'
-            ) + schematics_embedded_role,
-            'edit_active': blacklist(
-                'revisions', 'dateModified', 'dateCreated', 'monitoringPeriod',
-                'doc_id', '_attachments', 'tender_id', 'monitoring_id', 'decision',
-                'tender_owner_token', 'tender_owner'
-            ) + schematics_embedded_role,
+            'edit_draft': whitelist("reasons", "procuringStages", "monitoringPeriod", "decision") + _perm_edit_whitelist,
+            'edit_active': whitelist("conclusion") + _perm_edit_whitelist,
             'view': blacklist(
                 'tender_owner_token', '_attachments', 'revisions'
             ) + schematics_embedded_role,

--- a/openprocurement/audit/api/tests/test_conclusion.py
+++ b/openprocurement/audit/api/tests/test_conclusion.py
@@ -20,7 +20,7 @@ class MonitorConclusionResourceTest(BaseWebTest):
                     "violationType": "corruptionProcurementMethodType",
                 }
             }},
-            status=403,
+            status=422,
         )
 
     def test_decision_and_conclusion(self):
@@ -37,7 +37,7 @@ class MonitorConclusionResourceTest(BaseWebTest):
                     "violationOccurred": True,
                     "violationType": "corruptionProcurementMethodType",
                 }
-            }}, status=403
+            }}, status=422
         )
 
 

--- a/openprocurement/audit/api/tests/test_monitor.py
+++ b/openprocurement/audit/api/tests/test_monitor.py
@@ -31,7 +31,7 @@ class MonitorResourceTest(BaseWebTest):
         self.app.patch_json(
             '/monitors/{}'.format(self.monitor_id),
             {"data": {"status": "active"}},
-            status=403
+            status=422
         )
 
     @freeze_time('2018-01-01T12:00:00.000000+03:00')
@@ -72,16 +72,15 @@ class MonitorResourceTest(BaseWebTest):
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(response.json['data']["status"], "active")
 
-        response = self.app.patch_json(
+        self.app.patch_json(
             '/monitors/{}'.format(self.monitor_id),
             {"data": {
                 "decision": {
                     "description": "text_changed",
                 }
             }},
-            status=403
+            status=422
         )
-        self.assertEqual(response.status, '403 Forbidden')
 
 
 def suite():


### PR DESCRIPTION
1) edit roles have been made more clear
2) a new complex validation rule that checks forbidden fields in current status has been added to validate_patch_monitor_data 
3) a new status changes validation rule has been added (example _validate_patch_monitor_status_draft_to_active) 
4) some validation error response codes have been changed from 403 to 422